### PR TITLE
remake good links

### DIFF
--- a/app/views/team_maker/home.html.erb
+++ b/app/views/team_maker/home.html.erb
@@ -1,4 +1,4 @@
 <h1>Team Maker</h1>
-<a class="BlueButton" href="make">チームを作成</a>
-<a class="GreenButton" href="join">チームに参加</a>
-<a class="BlueButton" href="result">結果を表示</a>
+<a class="BlueButton" href="/team_maker/make">チームを作成</a>
+<a class="GreenButton" href="/team_maker/join">チームに参加</a>
+<a class="BlueButton" href="/team_maker/result">結果を表示</a>


### PR DESCRIPTION
リンクを相対パスから絶対パスに変えたよ
デフォルトページをteam_maker/homeにしてもちゃんとリンクできるようになった